### PR TITLE
Add vanilla JS Spotify genre album finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# codex_spotify_finder
+# Spotify Finder
+
+A simple vanilla JavaScript app that searches Spotify for albums released in a selected genre over a custom date range.
+
+## Usage
+
+1. Obtain a Spotify access token using the Client Credentials Flow and expose it as a global variable `SPOTIFY_ACCESS_TOKEN` before loading `app.js`.
+2. Open `index.html` in a browser.
+3. Select a genre, adjust the start and end dates if needed, and click **Search** to view recent albums.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,89 @@
+const API_BASE = 'https://api.spotify.com/v1';
+
+// Assume SPOTIFY_ACCESS_TOKEN is defined globally
+const token = typeof SPOTIFY_ACCESS_TOKEN !== 'undefined' ? SPOTIFY_ACCESS_TOKEN : '';
+
+async function fetchGenres() {
+  const res = await fetch(`${API_BASE}/recommendations/available-genre-seeds`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const data = await res.json();
+  const datalist = document.getElementById('genre-list');
+  data.genres.forEach((genre) => {
+    const option = document.createElement('option');
+    option.value = genre;
+    datalist.appendChild(option);
+  });
+}
+
+function initDateInputs() {
+  const endInput = document.getElementById('end-date');
+  const startInput = document.getElementById('start-date');
+  const today = new Date();
+  const weekAgo = new Date();
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  endInput.value = today.toISOString().split('T')[0];
+  startInput.value = weekAgo.toISOString().split('T')[0];
+}
+
+async function handleSearch(e) {
+  e.preventDefault();
+  const genre = document.getElementById('genre-input').value.trim();
+  const startDate = new Date(document.getElementById('start-date').value);
+  const endDate = new Date(document.getElementById('end-date').value);
+  if (!genre) return;
+
+  const artistsRes = await fetch(`${API_BASE}/search?q=${encodeURIComponent(`genre:"${genre}"`)}&type=artist&limit=10`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const artistsData = await artistsRes.json();
+  const artists = artistsData.artists ? artistsData.artists.items : [];
+
+  const albumPromises = artists.map(async (artist) => {
+    const res = await fetch(`${API_BASE}/artists/${artist.id}/albums?include_groups=album,single&limit=10`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await res.json();
+    return data.items.map((album) => ({ album, artist }));
+  });
+
+  const albumArrays = await Promise.all(albumPromises);
+  const allAlbums = albumArrays.flat();
+
+  const filtered = allAlbums.filter(({ album }) => {
+    const releaseDate = new Date(album.release_date);
+    return releaseDate >= startDate && releaseDate <= endDate;
+  });
+
+  renderResults(filtered);
+}
+
+function renderResults(items) {
+  const container = document.getElementById('results');
+  container.innerHTML = '';
+  if (items.length === 0) {
+    container.textContent = 'No results found.';
+    return;
+  }
+  items.forEach(({ album, artist }) => {
+    const card = document.createElement('div');
+    card.className = 'album';
+    const image = album.images && album.images[0] ? album.images[0].url : '';
+    card.innerHTML = `
+      <img src="${image}" alt="Album cover" />
+      <div class="info">
+        <a href="${album.external_urls.spotify}" target="_blank" rel="noopener">${album.name}</a>
+        <p>${artist.name}</p>
+        <p>Released: ${album.release_date}</p>
+      </div>
+    `;
+    container.appendChild(card);
+  });
+}
+
+window.addEventListener('load', () => {
+  initDateInputs();
+  fetchGenres();
+  document.getElementById('search-form').addEventListener('submit', handleSearch);
+});
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spotify Finder</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Spotify Finder</h1>
+  <form id="search-form">
+    <div class="form-group">
+      <label for="genre-input">Genre:</label>
+      <input id="genre-input" list="genre-list" required />
+      <datalist id="genre-list"></datalist>
+    </div>
+    <div class="form-group">
+      <label for="start-date">Start Date:</label>
+      <input type="date" id="start-date" required />
+    </div>
+    <div class="form-group">
+      <label for="end-date">End Date:</label>
+      <input type="date" id="end-date" required />
+    </div>
+    <button type="submit">Search</button>
+  </form>
+  <div id="results" class="results"></div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+button {
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.album {
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+
+.album img {
+  max-width: 100%;
+  height: auto;
+}
+
+.album .info {
+  margin-top: 10px;
+}
+
+.album .info a {
+  font-weight: bold;
+  text-decoration: none;
+  color: #1db954;
+}


### PR DESCRIPTION
## Summary
- add simple web app to search Spotify albums by genre and date range
- populate searchable genre dropdown from Spotify's available genre seeds
- filter artist albums by release date and display cover, link, and release info

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688be891c5908323b9315d542cedcf8d