### PR TITLE
Add Spotify token injection and auto-refresh for expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A simple vanilla JavaScript app that searches Spotify for albums released in a s
 
 ## Usage
 
-1. Obtain a Spotify access token using the Client Credentials Flow and expose it as a global variable `SPOTIFY_ACCESS_TOKEN` before loading `app.js`.
+1. Obtain a Spotify access token using the [Client Credentials Flow](https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow).  One way is with curl:
+
+   ```bash
+   curl -X POST -H "Authorization: Basic <base64(client_id:client_secret)>" \
+        -d grant_type=client_credentials \
+        https://accounts.spotify.com/api/token
+   ```
+
+   Copy the returned `access_token` and place it in `index.html` as the value of `SPOTIFY_ACCESS_TOKEN`.
+   The token expires after one hour; the page automatically reloads when that happens.
 2. Open `index.html` in a browser.
 3. Select a genre, adjust the start and end dates if needed, and click **Search** to view recent albums.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,12 @@
     <button type="submit">Search</button>
   </form>
   <div id="results" class="results"></div>
-
+  
+  <script>
+    const SPOTIFY_ACCESS_TOKEN = 'YOUR_VALID_ACCESS_TOKEN';
+    // Refresh the page when the token expires (1 hour)
+    setTimeout(() => window.location.reload(), 60 * 60 * 1000);
+  </script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inject `SPOTIFY_ACCESS_TOKEN` before loading the app script
- auto-reload the page after one hour to handle token expiry
- document how to obtain a token with the Client Credentials Flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688becd0a3648323b9b02843ee80fd3a